### PR TITLE
Remove Privacy Badger as we already have uBlock Origin

### DIFF
--- a/_guides/personalcomputer.md
+++ b/_guides/personalcomputer.md
@@ -18,7 +18,7 @@ You may also have a personal computer that you use for activities like online ba
 
 -   Use a Chrome or Firefox for browsing and keep it up to date.
 
--   Install an ad blocker like uBlock Origin and browser privacy extension like Privacy Badger.
+-   Install an ad blocker like uBlock Origin.
 
 -   Install and use a password manager that can securely sync across your personal devices, for both mobile and desktop use, such as [Dashlane](https://www.dashlane.com/), [Lastpass](https://www.lastpass.com/) or [1Password](https://1password.com/). Ensure you have selected a very strong master password. 
 


### PR DESCRIPTION
The Privacy Badger vastly overlaps with uBlock Origin. The net gain is negligible while significant risk is being introduced by any next browser plugin (could get hijacked etc). Also, the two plugins were not designed to work together and can interact in unexpected ways. Less is more. For details search /r/privacytoolsio community.